### PR TITLE
Fix a deprecation warning in React 16

### DIFF
--- a/src/withJob.js
+++ b/src/withJob.js
@@ -74,11 +74,11 @@ export default function withJob(config) {
             : this.context.jobs.get(id)
         }
 
-        this.state = {
+        this.setState({
           data: result ? result.data : null,
           error: null,
           completed: result != null,
-        }
+        })
       }
 
       componentDidMount() {


### PR DESCRIPTION
"Assigning directly to this.state is deprecated (except inside a component's constructor). Use setState instead."