### PR TITLE
Updated react peerDependency to ^16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.0.0",
-    "react": "^14.0.0 || ^15.0.0"
+    "react": "^14.0.0 || ^15.0.0|| ^16.0.0"
   },
   "devDependencies": {
     "app-root-dir": "1.0.2",


### PR DESCRIPTION
I'm getting a few npm warnings every time I install react-jobs. Considering react@16.0.0 is backward compatible, setting it as a peerDependency shouldn't emit warnings.