### PR TITLE
prevent utils.isPromise to crash when passing null

### DIFF
--- a/src/__tests__/__snapshots__/withJob.test.js.snap
+++ b/src/__tests__/__snapshots__/withJob.test.js.snap
@@ -59,3 +59,13 @@ exports[`withJob() rendering should set the "result" immediately if the work doe
   </ResultRenderer>
 </WithJob(ResultRenderer)>
 `;
+
+exports[`withJob() rendering should set the "result" immediately if the work return null 1`] = `
+<WithJob(ResultRenderer)>
+  <ResultRenderer
+    jobResult={null}
+  >
+    <div />
+  </ResultRenderer>
+</WithJob(ResultRenderer)>
+`;

--- a/src/__tests__/withJob.test.js
+++ b/src/__tests__/withJob.test.js
@@ -63,6 +63,13 @@ fdescribe('withJob()', () => {
       expect(mount(<ResultRendererWithJob />)).toMatchSnapshot()
     })
 
+    it('should set the "result" immediately if the work return null', () => {
+      const ResultRendererWithJob = withJob({ work: () => null })(
+        ResultRenderer,
+      )
+      expect(mount(<ResultRendererWithJob />)).toMatchSnapshot()
+    })
+
     it('should provide the props to the work function', () => {
       const expected = { foo: 'bar', baz: 'qux' }
       let actual

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ export function getDisplayName(WrappedComponent) {
 }
 
 export const isPromise = x =>
-  typeof x === 'object' && typeof x.then === 'function'
+  x && typeof x === 'object' && typeof x.then === 'function'
 
 export const propsWithoutInternal = props => {
   // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
hello,

Due to `typeof null === 'object` the isPromise test is crashing when passing `null`

Here a demo: https://codesandbox.io/s/3vyq17zy35

This PR fix that